### PR TITLE
Don't assign a (N,1) array to a (M, ) array

### DIFF
--- a/OpenElectrophy/gui/viewers/signalviewer.py
+++ b/OpenElectrophy/gui/viewers/signalviewer.py
@@ -271,7 +271,7 @@ class SignalViewer(ViewerBase):
                 else:
                     g = p.param('gain').value()
                     o = p.param('offset').value()
-                    curve.setData(t_vect, chunk*g+o)
+                    curve.setData(t_vect, (chunk*g+o)[:, 0])
         
         self.vline.setPos(self.t)
         self.plot.setXRange( t_start, t_stop)

--- a/OpenElectrophy/gui/viewers/timefreqviewer.py
+++ b/OpenElectrophy/gui/viewers/timefreqviewer.py
@@ -336,7 +336,7 @@ class TimeFreqViewer(ViewerBase):
                 chunk2[:]=0
                 i1 = -sl2.start if sl2.start<0 else 0
                 i2 = i1+chunk.size
-                chunk2[i1:i2] = chunk
+                chunk2[i1:i2] = chunk[:, 0]
                 chunk = chunk2
             self.threads[i].sig = chunk
             


### PR DESCRIPTION
This fixes the problem described in https://groups.google.com/forum/#!topic/openelectrophy/N7x0DDqpiXY where it excepts a data array of `(N, )` or `(N, 2)` but does not accept a `(N, 1)` which is the shape of the data originally passed. This fixes it by removing the (empty) second dimension of the data.