### PR TITLE
tables throws TypeError when selecting db path in osx

### DIFF
--- a/OpenElectrophy/gui/opendb.py
+++ b/OpenElectrophy/gui/opendb.py
@@ -184,17 +184,22 @@ class TypeSQLiteHDF5(DbConnect):
     
     
     icon =  ':/sqlite_hdf5.png'
-    
+
+    def unicode_values_to_str(self, d):
+        for a, v in d.iteritems():
+            if isinstance(v, unicode):
+                d[a] = d[a].encode('utf-8')
+        return d
 
     def get_opendb_kargs(self):
-        p = self.params_open.to_dict()
+        p = self.unicode_values_to_str(self.params_open.to_dict())
         return dict(url = 'sqlite:///'+p['sqlite_filename'],
                                 hdf5_filename = p['hdf5_filename'],
                                 numpy_storage_engine = 'hdf5',
                                 )
         
     def create_a_new_db(self):
-        p = self.params_create.to_dict()
+        p = self.unicode_values_to_str(self.params_create.to_dict())
         url = 'sqlite:///'+p['sqlite_filename']
         engine = create_engine( url )
         engine.connect()


### PR DESCRIPTION
i am getting a TypeError whenever i try to create or open an sqlite/hdf5 setup. i guess tables checks the type of the supplied hdf filename and wants a str instance. the returned values from the gui are unicode instances which might be an issue specific to mac os x.

i am not sure if this is the best way to handle this problem but as of now it is the only way i can use hdf5 with o.e. so maybe it helps someone. not sure if this causes problems elsewhere and i only included the conversion in the hdf5 fcuntion since i don't think it is relevant to the other db libs (sqlite accepts the unicode instances).

setup to reproduce:
osx 10.11.6
python 2.7.12
neo 0.4.1
tables 3.2.3.1
hdf5 1.8.16_1
